### PR TITLE
Add partial orders, agenda management, mechanism for precondition checks

### DIFF
--- a/expertino/clips/action/action-agenda.clp
+++ b/expertino/clips/action/action-agenda.clp
@@ -1,0 +1,101 @@
+; The agenda module manages the set of actions currently ready for execution or in progress.
+; An agenda is created from a plan that was selected for execution and is updated based on the
+; current progress within the partial order of the plan. The agenda is used to determine the
+; next actions to execute and to check the preconditions of actions that are ready for execution
+; before assigning them to executors. 
+
+(defrule agenda-select-first-plan
+  (not (pddl-plan (state EXECUTING)))
+  (not (agenda (plan ?)))
+  ?plan <- (pddl-plan (id ?plan-id))
+  =>
+  (assert (agenda (plan ?plan-id) (state ACTIVE)))
+)
+
+(defrule agenda-step-ahead
+  ?ag <- (agenda (plan ?plan-id) (class-selection ?ordering-class))
+  (not
+    (and
+      (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?ordering-class))
+      (not (agenda-action-item (plan ?plan-id) (action ?action-id)))
+    )
+  )
+  (not
+    (and
+      (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?ordering-class))
+      (agenda-action-item (plan ?plan-id) (action ?action-id) (execution-state ~COMPLETED))
+    )
+  )
+  (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?action-order-class&:(> ?action-order-class ?ordering-class)))
+  =>
+  (modify ?ag (class-selection (+ ?ordering-class 1)))
+)
+
+(defrule agenda-add-action
+  (agenda (plan ?plan-id) (class-selection ?ordering-class) (class-relaxation ?relaxation))
+  (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?ordering-class))
+  (not (agenda-action-item (plan ?plan-id) (action ?action-id)))
+  =>
+  (assert (agenda-action-item (action ?action-id) (plan ?plan-id)))
+  (printout red "Added action " ?action-id "(ordering " ?ordering-class ") to agenda" crlf)
+)
+
+(defrule agenda-add-action-relaxed
+  (agenda (plan ?plan-id) (class-selection ?ordering-class-selected) (class-relaxation ?relaxation))
+  (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?plan-order-class&:(>= ?ordering-class-selected  (- ?plan-order-class ?relaxation))))
+  ?precon <- (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PRECONDITION-SAT) (context AGENDA-LOOKAHEAD))
+  (not (agenda-action-item (plan ?plan-id) (action ?action-id)))
+  =>
+  (assert (agenda-action-item (action ?action-id) (plan ?plan-id)))
+  (retract ?precon)
+  (printout red "Added action " ?action-id "(" ?plan-order-class ") to agenda (relaxed condition, precondition satisfied)" crlf)
+)
+
+(defrule agenda-add-action-relaxed-check
+    (agenda (plan ?plan-id) (class-selection ?ordering-class-selected) (class-relaxation ?relaxation))
+    (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?plan-order-class&:(>= ?ordering-class-selected  (- ?plan-order-class ?relaxation))))
+    (not (pddl-action-precondition (plan ?plan-id) (id ?action-id) (context AGENDA-LOOKAHEAD)))
+    (not (agenda-action-item (plan ?plan-id) (action ?action-id)))
+    =>
+    (assert (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PENDING) (context AGENDA-LOOKAHEAD)))
+    (printout red "Checking action " ?action-id "(ordering " ?plan-order-class ") for preconditions, relaxed agenda candidate" crlf)
+)
+
+(defrule agenda-add-action-relaxed-reset
+  (agenda (plan ?plan-id) (class-selection ?ordering-class-selected) (class-relaxation ?relaxation))
+  (pddl-action (id ?action-id) (plan ?plan-id) (plan-order-class ?plan-order-class&:(>= ?ordering-class-selected  (- ?plan-order-class ?relaxation))))
+  (not (agenda-action-item (plan ?plan-id) (action ?action-id)))
+  (agenda-action-item (plan ?plan-id) (action ?completed-action-id&:(neq ?completed-action-id ?action-id)) (execution-state EFFECTS-APPLIED))
+  ?precon <- (pddl-action-precondition (plan ?plan-id) (id ?action-id) (context AGENDA-LOOKAHEAD) (state PRECONDITION-UNSAT|PRECONDITION-SAT|PENDING))
+  =>
+  (retract ?precon)
+)
+
+(defrule agenda-action-check-start
+  (agenda-action-item (plan ?plan-id) (action ?action-id) (execution-state PENDING))
+  (not (pddl-action-precondition (plan ?plan-id) (id ?action-id) (context AGENDA-SELECTION)))
+  =>
+  (assert (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PENDING) (context AGENDA-SELECTION)))
+)
+
+(defrule agenda-action-check-reset
+  (agenda-action-item (plan ?plan-id) (action ?action-id) (execution-state PENDING))
+  ?precon <- (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PRECONDITION-UNSAT|PRECONDITION-SAT|PENDING) (context AGENDA-SELECTION))
+  (agenda-action-item (plan ?plan-id) (action ?completed-action-id&:(neq ?completed-action-id ?action-id)) (execution-state EFFECTS-APPLIED))
+  =>
+  (retract ?precon)
+)
+
+(defrule agenda-action-print-sat
+  ;(agenda-action-item (plan ?plan-id) (action ?action-id) (execution-state PENDING))
+  (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PRECONDITION-SAT) (context ?context))
+  =>
+  (printout green "Action " ?action-id " has satisfied preconditions for context " ?context crlf)
+)
+
+(defrule agenda-action-print-unsat
+  ;(agenda-action-item (plan ?plan-id) (action ?action-id) (execution-state PENDING))
+  (pddl-action-precondition (plan ?plan-id) (id ?action-id) (state PRECONDITION-UNSAT) (context ?context) (unsatisfied-preconditions $?unsats))
+  =>
+  (printout yellow "Action " ?action-id " has unsatisfied preconditions: " ?unsats " for context " ?context crlf)
+)

--- a/expertino/clips/deftemplates.clp
+++ b/expertino/clips/deftemplates.clp
@@ -382,14 +382,15 @@
   @slot instance: pddl instance belonging to the action.
   @slot name: name of the action.
   @slot params: parameters of the  action.
-  @slot state: TBD
+  @slot plan-order-class: partial order class of the action in theplan
+  @slot: planned-start-time: start time of the action in the plan
+  @slot: planned-duration: assumed duration of the action according to plan
 "
   (slot instance (type SYMBOL))
   (slot id (type SYMBOL)) ; this should be a globally unique ID
   (slot plan (type SYMBOL))
   (slot name (type SYMBOL))
   (multislot params (type SYMBOL) (default (create$)))
-  (slot state (type SYMBOL)) ; initial, check-precond, precond-sat, exec-wait, exec, exec-done, effects-applied, failed final
   (slot plan-order-class (type INTEGER))
   (slot planned-start-time (type FLOAT))
   (slot planned-duration (type FLOAT))
@@ -411,3 +412,25 @@
   (slot state (type SYMBOL) (allowed-values PENDING WAITING START-EFFECT-APPLIED ERROR) (default PENDING))
 )
 
+(deftemplate pddl-action-precondition
+  (slot instance (type SYMBOL))
+  (slot plan (type SYMBOL))
+  (slot id (type SYMBOL))
+  (slot context (type SYMBOL))
+  (slot state (type SYMBOL) (allowed-values PENDING CHECK-PRECONDITION PRECONDITION-SAT PRECONDITION-UNSAT) (default PENDING))
+  (multislot unsatisfied-preconditions (type STRING) (default (create$)))
+)
+
+(deftemplate agenda
+  (slot plan (type SYMBOL))
+  (slot class-selection (type INTEGER) (default 0))
+  (slot class-relaxation (type INTEGER) (default 1))
+  (slot state (type SYMBOL) (allowed-values ACTIVE INACTIVE) (default INACTIVE))
+)
+
+(deftemplate agenda-action-item
+  (slot plan (type SYMBOL))
+  (slot action (type SYMBOL))
+  (slot execution-state (type SYMBOL) (allowed-values PENDING SELECTED EXECUTING COMPLETED ERROR EFFECTS-APPLIED) (default PENDING))
+  (slot priority (type INTEGER) (default 0))
+)

--- a/expertino/clips/deftemplates.clp
+++ b/expertino/clips/deftemplates.clp
@@ -370,6 +370,13 @@
   (slot value (type FLOAT))
 )
 
+(deftemplate pddl-plan
+  (slot id (type SYMBOL))
+  (slot instance (type SYMBOL))
+  (slot duration (type FLOAT))
+  (slot state (type SYMBOL) (allowed-values PENDING EXECUTING) (default PENDING))
+)
+
 (deftemplate pddl-action
 " Represents a grounded pddl action in a pddl instance.
   @slot instance: pddl instance belonging to the action.
@@ -379,9 +386,13 @@
 "
   (slot instance (type SYMBOL))
   (slot id (type SYMBOL)) ; this should be a globally unique ID
+  (slot plan (type SYMBOL))
   (slot name (type SYMBOL))
   (multislot params (type SYMBOL) (default (create$)))
   (slot state (type SYMBOL)) ; initial, check-precond, precond-sat, exec-wait, exec, exec-done, effects-applied, failed final
+  (slot plan-order-class (type INTEGER))
+  (slot planned-start-time (type FLOAT))
+  (slot planned-duration (type FLOAT))
 )
 
 

--- a/expertino/clips/pddl/plan.clp
+++ b/expertino/clips/pddl/plan.clp
@@ -47,19 +47,26 @@
   =>
   (bind ?plan-found (expertino-msgs-plan-temporal-result-get-field ?res-ptr "success"))
   (printout green "planning done" crlf)
+  (bind ?plan-id (gensym*))
+  (bind ?instance nil)
   (if ?plan-found then
     (bind ?plan (expertino-msgs-plan-temporal-result-get-field ?res-ptr "actions"))
-	(foreach ?action ?plan
-	(bind ?instance (sym-cat (expertino-msgs-timed-plan-action-get-field ?action "pddl_instance")))
-	(bind ?name (sym-cat (expertino-msgs-timed-plan-action-get-field ?action "name")))
-	(bind ?args (expertino-msgs-timed-plan-action-get-field ?action "args"))
-	(bind ?arg-syms (create$))
-	(foreach ?arg ?args
-	  (bind ?arg-syms (create$ ?arg-syms (sym-cat ?arg)))
-	)
-	(assert (pddl-action (id (gensym*)) (instance ?instance) (name ?name) (params ?arg-syms) (state INITIAL)))
-	)
+    (foreach ?action ?plan
+      (bind ?instance (sym-cat (expertino-msgs-timed-plan-action-get-field ?action "pddl_instance")))
+      (bind ?name (sym-cat (expertino-msgs-timed-plan-action-get-field ?action "name")))
+      (bind ?args (expertino-msgs-timed-plan-action-get-field ?action "args"))
+      (bind ?arg-syms (create$))
+      (foreach ?arg ?args
+        (bind ?arg-syms (create$ ?arg-syms (sym-cat ?arg)))
+      )
+      (bind ?equiv_class (expertino-msgs-timed-plan-action-get-field ?action "equiv_class"))
+      (bind ?ps-time (expertino-msgs-timed-plan-action-get-field ?action "start_time"))
+      (bind ?p-duration (expertino-msgs-timed-plan-action-get-field ?action "duration"))
+      (assert (pddl-action (id (gensym*)) (plan ?plan-id) (instance ?instance) (name ?name) (params ?args) (plan-order-class ?equiv_class) (planned-start-time ?ps-time) (planned-duration ?p-duration)))
+    )
   )
+
+  (assert (pddl-plan (id ?plan-id)))
 	(expertino-msgs-plan-temporal-result-destroy ?res-ptr)
 	(expertino-msgs-plan-temporal-goal-destroy ?goal-ptr)
 	(expertino-msgs-plan-temporal-client-goal-handle-destroy ?cgh-ptr)

--- a/expertino/params/clips_env_manager.yaml
+++ b/expertino/params/clips_env_manager.yaml
@@ -58,6 +58,8 @@ clips_manager:
         "clips/expertino/sim-interface.clp",
         "clips/expertino/orders/order-selection.clp",
         "clips/expertino/action-sim-bindings.clp",
+        "clips/expertino/action/action-agenda.clp",
+        "clips/expertino/action/action-precond-check.clp",
         # Finalize
         "clips/expertino/shutdown/finalize-ros.clp",
         ]

--- a/expertino_msgs/msg/TimedPlanAction.msg
+++ b/expertino_msgs/msg/TimedPlanAction.msg
@@ -3,3 +3,4 @@ string name
 string[] args
 float64 start_time
 float64 duration
+int64 equiv_class


### PR DESCRIPTION
This PR:
- adds a simple version of partial orders to plans
- adds the concept of an agenda of actions to the agent 
  - the agenda manages actions currently available for execution by considering the partial order classes of the plan
  - has a look ahead window for partial order classes of the plan
  - takes care of precondition checks for actions on the agenda
- moves precondition checks to their own facts for better management and separation
- moves execution information out of PDDL actions and to the agenda